### PR TITLE
chore: copy peerDependencies to devDependencies

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 const { sync: whichSync } = require('which')
 const { spawnSync } = require('child_process')
+const { resolve } = require('path')
+const cwd = process.cwd()
 
 const run = (cmd, ...args) => {
   cmd = whichSync(cmd)
@@ -20,7 +22,7 @@ run('npm', 'uninstall', ...pkgs)
 run('npm', 'install', require('../package.json').name, '--save-dev')
 const { unlinkSync } = require('fs')
 try {
-  unlinkSync('.eslintrc.json')
+  unlinkSync(resolve(cwd, '.eslintrc.json'))
 } catch (er) {
   if (er.code !== 'ENOENT')
     throw er

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 
 const { resolve } = require('path')
+const cwd = process.cwd()
 const { readdirSync, writeFileSync, existsSync } = require('fs')
-const pjFile = resolve(process.cwd(), 'package.json')
+const pjFile = resolve(cwd, 'package.json')
 const getPkg = () => {
   try {
     return require(pjFile)
@@ -18,12 +19,12 @@ const force = process.argv.includes('--force') ||
 pkg.scripts = pkg.scripts || {}
 const { scripts } = pkg
 const lintFiles = []
-const entries = readdirSync('.')
+const entries = readdirSync(cwd)
 if (entries.some(f => /\.[cm]?js$/.test(f)))
   lintFiles.push('"*.*js"')
-if (existsSync('lib'))
+if (existsSync(resolve(cwd, 'lib')))
   lintFiles.push('"lib/**/*.*js"')
-if (existsSync('test') && lintFiles.length)
+if (existsSync(resolve(cwd, 'test')) && lintFiles.length)
   lintFiles.push('"test/**/*.*js"')
 if (!lintFiles.length)
   lintFiles.push('"*.*js" "lib/**/*.*js" "test/**/*.*js"')

--- a/package.json
+++ b/package.json
@@ -33,7 +33,12 @@
     "check-coverage": true
   },
   "devDependencies": {
-    "tap": "^15.0.9"
+    "tap": "^15.0.9",
+    "eslint": "^7.26.0",
+    "eslint-plugin-import": "^2.23.2",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-promise": "^5.1.0",
+    "eslint-plugin-standard": "^5.0.0"
   },
   "peerDependencies": {
     "eslint": "^7.26.0",

--- a/test/init.js
+++ b/test/init.js
@@ -29,8 +29,9 @@ const fsMock = { ...require('fs') }
 const init = require.resolve('../lib/init.js')
 const which = require.resolve('which')
 const runInit = t => {
-  const cwd = process.cwd()
-  process.chdir(t.testdirName)
+  const { cwd } = process
+  const { testdirName } = t
+  process.cwd = () => testdirName
   t.mock(init, {
     [which]: {
       sync: cmd => cmd === process.execPath ? 'execPath' : `/which/${cmd}`,
@@ -43,7 +44,7 @@ const runInit = t => {
       },
     },
   })
-  process.chdir(cwd)
+  process.cwd = cwd
 }
 
 t.test('basic init', t => {

--- a/test/setup.js
+++ b/test/setup.js
@@ -4,12 +4,13 @@ process.env.npm_config_force = 'false'
 const setup = require.resolve('../lib/setup.js')
 const argv = process.argv
 const runSetup = (t, ...args) => {
-  const cwd = process.cwd()
-  t.teardown(() => process.chdir(cwd))
-  process.chdir(t.testdirName)
+  const { cwd } = process
+  const { testdirName } = t
+  process.cwd = () => testdirName
   process.argv = [process.argv[0], process.argv[1], ...args]
   t.mock(setup)
   process.argv = argv
+  process.cwd = cwd
 }
 
 t.test('fresh setup', t => {


### PR DESCRIPTION
npm 6 doesn't install peerDeps the same way, and npm 7 allows them to
coexist as devs.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
